### PR TITLE
Add support for ActionPack variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ Send a message using the `deliver` method:
 AccountNotifier.welcome.deliver email: 'user@gmail.com', sms: '+15557654321'
 ```
 
+### Variants (New with Rails 4.1)
+
+You can have different templates for each message type using [variants](http://edgeguides.rubyonrails.org/4_1_release_notes.html#action-pack-variants). *Right now, only the implicit template rendering is supported.*
+
+``` html+ruby
+<!-- app/views/account_notifier/welcome.html+email.erb -->
+<h1>Welcome!</h1>
+
+<!-- app/views/account_notifier/welcome.text+email.erb -->
+Welcome! (email)
+
+<!-- app/views/account_notifier/welcome.text+sms.erb -->
+Welcome! (sms)
+```
+
+
 Configuration
 -------------
 

--- a/spec/internal/app/notifiers/base_notifier.rb
+++ b/spec/internal/app/notifiers/base_notifier.rb
@@ -28,4 +28,7 @@ class BaseNotifier < Outbox::Notifier
       body 'Explicit Message'
     end
   end
+
+  def implicit_variants
+  end
 end

--- a/spec/internal/app/views/base_notifier/implicit_variants.text+email.erb
+++ b/spec/internal/app/views/base_notifier/implicit_variants.text+email.erb
@@ -1,0 +1,1 @@
+Email Variant

--- a/spec/internal/app/views/base_notifier/implicit_variants.text+sms.erb
+++ b/spec/internal/app/views/base_notifier/implicit_variants.text+sms.erb
@@ -1,0 +1,1 @@
+SMS Variant

--- a/spec/outbox/notifier_spec.rb
+++ b/spec/outbox/notifier_spec.rb
@@ -97,5 +97,13 @@ describe Outbox::Notifier do
         BaseNotifier.explicit_sms_message
       }.to raise_error(ActionView::MissingTemplate)
     end
+
+    if Rails.version >= '4.1'
+      it 'supports implicit variants by message type' do
+        message = BaseNotifier.implicit_variants
+        expect(message.email.body.encoded.strip).to eql('Email Variant')
+        expect(message.sms.body.strip).to eql('SMS Variant')
+      end
+    end
   end
 end


### PR DESCRIPTION
Using [ActionPack variants](http://edgeguides.rubyonrails.org/4_1_release_notes.html#action-pack-variants) we can have different templates for each message type (email, sms, etc).
